### PR TITLE
added -f so make clean doesn't fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,6 @@ clean :
 	rm -rf $(BINS) $(OBJ)
 	rm -rf test/test.dat.output*
 	rm -rf *.output*
-	rm biqbin.so
+	rm -f biqbin.so
 
 


### PR DESCRIPTION
Small fix to handle make clean, when biqbin.so is not created yet.